### PR TITLE
the repo secret had a problem this telegram group suggested the fix with cloning error while running the work flow

### DIFF
--- a/.github/workflows/mirror-bot.yml
+++ b/.github/workflows/mirror-bot.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Clone Mirror Repo
         run: |
-          git clone https://${{ secrets.GH_TOKEN }}/${GitHubName}/${{ secrets.REPO }} source
+          git clone https://${{ secrets.GH_TOKEN }}@github.com/${GitHubName}/${{ secrets.REPO }} source
 
       - name: Compile Docker
         run: |


### PR DESCRIPTION
https://github.com/rahulkhatri137/mirrorbot-workflow/blob/cdea04677a1efb65b7e4308ac86155ba5eff690e/.github/workflows/mirror-bot.yml#L30

Change this line to 
git clone https://${{ secrets.GH_TOKEN }}@github.com/${GitHubName}/${{ secrets.REPO }} source

And just add ur repo name in REPO
Dont use this format https://t.me/mirrorsociety/60408